### PR TITLE
Pull request/suggestions for search widget issues

### DIFF
--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -127,7 +127,7 @@ define(['underscore',
         //modifies apiQuery in place
         SecondarySort.addSecondarySort(apiQuery);
 
-        this.original_url = apiQuery.url();
+        this.original_url = this.queryUpdater.clean(apiQuery).url();
         this.original_query = apiQuery.get("q")
 
         // checking if it's a new big query
@@ -213,7 +213,7 @@ define(['underscore',
           return;
         }
 
-        if (apiQuery.get("q")[0].indexOf("simbid:") > -1) {
+        if (apiQuery.get("q")[0].indexOf("simbid") > -1) {
           apiQuery.add("__original_url", this.original_url);
           apiQuery.add("__original_query", this.original_query);
         }

--- a/src/js/widgets/search_bar/autocomplete.js
+++ b/src/js/widgets/search_bar/autocomplete.js
@@ -38,6 +38,8 @@ define([
 
     {value: "orcid:" , label : "ORCiD identifier", match: "orcid:"},
 
+    {value: "object:" , label : "SIMBAD object (e.g. object:LMC)", match: "object:"},
+
     {value: "citations()" , label : "Citations", desc: "Get papers citing your search result set", match: "citations("},
     {value: "references()" , label : "References", desc: "Get papers referenced by your search result set", match: "references("},
 

--- a/src/js/widgets/search_bar/search_bar_widget.js
+++ b/src/js/widgets/search_bar/search_bar_widget.js
@@ -295,7 +295,6 @@ define([
           "keypress #search-form-container" : function(){
             //for analytics
             //this is not exact (might have experimented then closed the builder)
-            // but it's close enough
             this._queryBuilderUsed = true;
           }
         },
@@ -320,13 +319,8 @@ define([
         },
 
         setFormVal: function(v) {
-          if (this.original_query) {
-            this.$(".q").val(this.original_query);
-          } else {
-            this.$(".q").val(v);
-          }
+          this.$(".q").val(v);
           this.toggleClear();
-
         },
 
         setNumFound : function(numFound){
@@ -410,7 +404,6 @@ define([
               newVal = operator + "(" + currentVal + ")";
               currentVal = "";
               this.setFormVal(newVal);
-              this.toggleClear();
               return
             }
 
@@ -441,9 +434,6 @@ define([
               this.$input.selectRange( newString.length );
             }
           }
-
-          //figure out if clear button needs to be there
-          this.toggleClear();
 
           analytics('send', 'event', 'interaction', 'field-insert-button-pressed', df);
 
@@ -531,27 +521,17 @@ define([
         },
 
         handleFeedback: function(feedback) {
-          switch (feedback.code) {
 
-            case ApiFeedback.CODES.SEARCH_CYCLE_STARTED:
-              this.setCurrentQuery(feedback.query);
-              if (feedback.response.responseHeader.params["__original_query"]) {
-                var newq = feedback.response.responseHeader.params["__original_query"];
-                this.view.setFormVal(newq);
-              } else {
-                this.view.setFormVal(feedback.query.get('q').join(' '));
-              }
-              this.view.setNumFound(feedback.numFound || 0);
-              break;
-            case ApiFeedback.CODES.SEARCH_CYCLE_FAILED_TO_START:
-              //still want search bar to reflect failed search (from form widgets)
-              var q = feedback.request.get("query").get("q").join(' ');
-              this.setCurrentQuery(q);
-              this.view.setFormVal(q);
-              this.view.setNumFound(0);
-              break;
+          if (feedback.code === ApiFeedback.CODES.SEARCH_CYCLE_STARTED || feedback.code ===  ApiFeedback.CODES.SEARCH_CYCLE_FAILED_TO_START ) {
 
+            var query = feedback.query ? feedback.query : feedback.request.get("query");
+            var newq = query.get("__original_query") ? query.get("__original_query")[0] : query.get("q").join(" ");
+            
+            this.setCurrentQuery(feedback.query);
+            this.view.setFormVal(newq);
+            this.view.setNumFound(feedback.numFound || 0);
           }
+
         },
 
         initialize: function (options) {
@@ -569,12 +549,9 @@ define([
 
           this.listenTo(this.view, "render", function () {
             var query = this.getCurrentQuery().get("q");
-            if (query) {
-              this.view.setFormVal(query);
-              this.view.$(".icon-clear").removeClass("hidden");
-            } else {
-              this.view.$(".icon-clear").addClass("hidden");
-            }
+            if (query) this.view.setFormVal(query);
+            this.view.toggleClear();
+
           });
 
           BaseWidget.prototype.initialize.call(this, options)


### PR DESCRIPTION
- queryupdater.clean is now being called correctly for object searches
- object search no longer overrides setFormVal function, breaking search widget functionality e.g. quick add buttons
- added object: field to autocomplete

Warnings
1. I didn't add tests
2. The querybuilder tool is still broken, I'm not sure how to get it to work with the "fake" field of object. I wonder if we can ignore for now?
3. Object field still isn't activated in classic search form, I can do this once the main object search functionality is merged
4. I'm pretty sure I didn't mess any object query functionality up... but please still take a look at it to make sure
