### PR TITLE
removed done(), settimeouts, added test for startsearchcycle

### DIFF
--- a/src/js/components/query_mediator.js
+++ b/src/js/components/query_mediator.js
@@ -95,11 +95,11 @@ define(['underscore',
 
       doQueryTranslation: function(q) {
         var d = $.Deferred(),
-          pubsub = this.getPubSub(),
-          options = {
+            pubsub = this.getPubSub(),
+            options = {
             type : "POST",
             contentType : "application/json"
-          };
+            };
         // Send the entire query to the "query" endpoint of the "object_service" micro service
         // this endpoint will grab the "object:<expression>" from the query string and send back
         // a translated query string which will have "simbid:<expression with SIMBAD identifiers>"

--- a/test/mocha/js/components/query_mediator.spec.js
+++ b/test/mocha/js/components/query_mediator.spec.js
@@ -147,8 +147,7 @@ define([
 
       });
 
-      it("should be able to get SIMBAD identifiers for queries with 'object:' field", function(done){
-
+      it("should be able to get SIMBAD identifiers for queries with 'object:' field", function(){
 
         var qm =  createTestQM().qm;
 
@@ -168,26 +167,25 @@ define([
           "options": {"type": "POST","contentType": "application/json"}
         });
 
-        setTimeout(function() {
-          expect(publishSpy.args[0][0]).to.eql("[PubSub]-Execute-Request");
-          expect(publishSpy.args[0][1].get('query').url()).to.eql(r.get('query').url());
-          done();
-        }, 1);
+        expect(publishSpy.args[0][0]).to.eql("[PubSub]-Execute-Request");
+        expect(publishSpy.args[0][1].get('query').url()).to.eql(r.get('query').url());
 
         // Check that query mediator object has "original_query" and "original_url" attributes
-        setTimeout(function() {
-          expect(qm).to.have.all.keys('original_url', 'original_query');
-          done();
-        }, 1);
+        expect(qm.original_query).to.eql(["bibstem:ApJ object:Foo year:2001"]);
+        expect(qm.original_url).to.eql("q=bibstem%3AApJ%20object%3AFoo%20year%3A2001");
 
         // Check that response from API gets properly processed
         qm.getPubSub().publish(qm.getPubSub().DELIVERING_RESPONSE, new JsonResponse({"query":"bibstem:ApJ simbid:123456 year:2001"}));
 
-        setTimeout(function() {
-          expect(publishSpy.args[1][0]).to.eql("[PubSub]-New-Response");
-          expect(publishSpy.args[1][1].get('query')).to.eql("bibstem:ApJ simbid:123456 year:2001");
-          done();
-        }, 1);
+
+        expect(JSON.stringify(startSearch.args[0])).to.eql(JSON.stringify([
+          {
+            "q": [
+              "bibstem:ApJ simbid:123456 year:2001"
+            ]
+          },
+          "fakeKey"
+        ]));
 
         qm.startSearchCycle.restore();
 


### PR DESCRIPTION
Hi Edwin,

I think a problem was that you can only call done() 1x per test, it immediately ends the test when it is called so some of your later assertions weren't being run.

I removed the setTimeout calls in your test since I don't think they were necessary, but maybe I missed something about why you added them.

I replaced the test at the bottom from a test for the pubsub arguments (which isn't too helpful, since we can be pretty sure that line 178 in our test is correct) to a test to see that qm.startSearchCycle is called with the correct arguments in the "done" callback from the queryTranslation function.
